### PR TITLE
Throw an exception when ClamAV encounters an error

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -13,6 +13,11 @@ class ClamavValidator extends Validator
     const CLAMAV_STATUS_OK = 'OK';
 
     /**
+     * @const string CLAMAV_STATUS_ERROR
+     */
+    const CLAMAV_STATUS_ERROR = 'ERROR';
+
+    /**
      * @const string CLAMAV_UNIX_SOCKET
      */
     const CLAMAV_UNIX_SOCKET = '/var/run/clamav/clamd.ctl';
@@ -51,6 +56,10 @@ class ClamavValidator extends Validator
 
         // Scan the file
         $result = $quahog->scanFile($file);
+
+        if (self::CLAMAV_STATUS_ERROR === $result['status']) {
+            throw new ClamavValidatorException($result['reason']);
+        }
 
         // Check if scan result is not clean
         if (self::CLAMAV_STATUS_OK != $result['status']) {

--- a/src/ClamavValidator/ClamavValidatorException.php
+++ b/src/ClamavValidator/ClamavValidatorException.php
@@ -1,0 +1,7 @@
+<?php namespace Sunspikes\ClamavValidator;
+
+use Exception;
+
+class ClamavValidatorException extends Exception
+{
+}

--- a/tests/ValidatorClamavTest.php
+++ b/tests/ValidatorClamavTest.php
@@ -4,12 +4,14 @@ namespace Sunspikes\Tests\ClamavValidator;
 
 use Mockery;
 use Sunspikes\ClamavValidator\ClamavValidator;
+use Sunspikes\ClamavValidator\ClamavValidatorException;
 
 class ValidatorClamavTest extends \PHPUnit_Framework_TestCase
 {
     protected $translator;
     protected $clean_data;
     protected $virus_data;
+    protected $error_data;
     protected $rules;
     protected $messages;
 
@@ -23,11 +25,15 @@ class ValidatorClamavTest extends \PHPUnit_Framework_TestCase
         $this->virus_data = array(
             'file' => dirname(__FILE__) . '/files/test2.txt'
         );
+        $this->error_data = array(
+            'file' => dirname(__FILE__) . '/files/test3.txt'
+        );
         $this->messages = array();
     }
 
     public function tearDown()
     {
+        chmod($this->error_data['file'], 0644);
         Mockery::close();
     }
 
@@ -53,5 +59,21 @@ class ValidatorClamavTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertFalse($validator->passes());
+    }
+
+    public function testValidatesError()
+    {
+        $validator = new ClamavValidator(
+            $this->translator,
+            $this->error_data,
+            array('file' => 'clamav'),
+            $this->messages
+        );
+
+        chmod($this->error_data['file'], 0000);
+
+        $this->setExpectedException('\Sunspikes\ClamavValidator\ClamavValidatorException', 'Access denied.');
+
+        $validator->passes();
     }
 }

--- a/tests/files/test3.txt
+++ b/tests/files/test3.txt
@@ -1,0 +1,5 @@
+dfdsfdsfdsf
+ds
+fds
+fdsfds
+fdsfdsfds


### PR DESCRIPTION
When ClamAV encounters an error, it returns a status of 'ERROR' -- it would be helpful if this library propagated the error in order to facilitate debugging.

In my particular use case the clamav user didn't have read access to the file it was trying to scan, so I've included a unit test for that scenario.