### PR TITLE
Pass customAttributes along to parent constructor for validation

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -35,9 +35,14 @@ class ClamavValidator extends Validator
     /**
      * Creates a new instance of ClamavValidator
      */
-    public function __construct($translator, $data, $rules, $messages)
-    {
-        parent::__construct($translator, $data, $rules, $messages);
+    public function __construct(
+        Translator $translator,
+        array $data,
+        array $rules,
+        array $messages = [],
+        array $customAttributes = []
+    ) {
+        parent::__construct($translator, $data, $rules, $messages, $customAttributes);
     }
 
     /**

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -1,5 +1,6 @@
 <?php namespace Sunspikes\ClamavValidator;
 
+use Illuminate\Contracts\Translation\Translator;
 use Illuminate\Validation\Validator;
 use Xenolope\Quahog\Client;
 use Socket\Raw\Factory;
@@ -33,7 +34,14 @@ class ClamavValidator extends Validator
     const CLAMAV_SOCKET_READ_TIMEOUT = 30;
 
     /**
-     * Creates a new instance of ClamavValidator
+     * Creates a new instance of ClamavValidator]
+     *
+     * ClamavValidator constructor.
+     * @param Translator $translator
+     * @param array      $data
+     * @param array      $rules
+     * @param array      $messages
+     * @param array      $customAttributes
      */
     public function __construct(
         Translator $translator,

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -31,13 +31,13 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'clamav-validator');
 
         $this->app['validator']
-            ->resolver(function ($translator, $data, $rules, $messages, $attributes) {
+            ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
                 return new ClamavValidator(
                     $translator,
                     $data,
                     $rules,
                     $messages,
-                    $attributes
+                    $customAttributes
                 );
             });
 

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -31,12 +31,13 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'clamav-validator');
 
         $this->app['validator']
-            ->resolver(function ($translator, $data, $rules, $messages) {
+            ->resolver(function ($translator, $data, $rules, $messages, $attributes) {
                 return new ClamavValidator(
                     $translator,
                     $data,
                     $rules,
-                    $messages
+                    $messages,
+                    $attributes
                 );
             });
 


### PR DESCRIPTION
I've ran into the issue where the `customAttributes` aren't passed along to the parent constructor of the `ClamavValidator`

The constructor signature of Laravel's Validation class is as follows:
```php
public function __construct(Translator $translator, array $data, array $rules, array $messages = [], array $customAttributes = [])
```

And the constructor signature of `ClamavValidator` is:
```php
public function __construct($translator, $data, $rules, $messages)
```

This pull request fixes the missing parameter by changing `ClamavValidatorServiceProvider` and `ClamavValidator` so it honors Laravel's `Validator` class
