### PR TITLE
Fixing "Access Denied" errors on PHP uploads

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -62,7 +62,7 @@ class ClamavValidator extends Validator
         $quahog = new Client($socket, self::CLAMAV_SOCKET_READ_TIMEOUT, PHP_NORMAL_READ);
 
         // Scan the file
-        $result = $quahog->scanFile($file);
+        $result = $quahog->scanLocalFile($file);
 
         if (self::CLAMAV_STATUS_ERROR === $result['status']) {
             throw new ClamavValidatorException($result['reason']);


### PR DESCRIPTION
Seeing the issue log, the problem with "Access Denied" to uploaded files still persists. This is, in fact, a pretty obvious error: clamav-daemon is run by the clamav user by default. My web server uploads files with permission 600, which makes the file inaccessible by clamav. I tried the solution by manipulating the ACL records, but this did not worked. Since chmoding every upload to 644 is not a solution either there is a quick work around:
Instead of trying to let clamav accessing the file server side, just provide the stream - the web server will have permission to read from the file. Quahog even provides a method for this.