### PR TITLE
Bump PHP version to 5.5 due to the ::class usage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "xenolope/quahog": "2.*",
         "illuminate/support": ">=4.2",
         "illuminate/validation": ">=4.1.21"


### PR DESCRIPTION
The code does use ::class and ::class is introduced in PHP 5.5, see http://php.net/manual/en/migration55.new-features.php#migration55.new-features.class-name