### PR TITLE
- Introduce configuration file to be able to use config:cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ If you are using Laravel < 5.5, you need to add `Sunspikes\ClamavValidator\Clama
 	Sunspikes\ClamavValidator\ClamavValidatorServiceProvider::class,
 ),
 ```
+#### 3. Publish assets from the the vendor package
+
+##### Config file
+
+The default configuration file does use `ENV` to override the defaults. If you want to change the configuration file 
+anyway you run the following command to publish the package config file:
+
+    php artisan vendor:publish --provider="Sunspikes\ClamavValidator\ClamavValidatorServiceProvider" --tag=config
+
+Once the command is finished you should have a `config/clamav.php` file that will be used as well.
+
+##### Language files
+
+If you want to customize the translation or add your own language you can run the the following command to
+publish the language files to a folder you maintain:
+
+    php artisan vendor:publish --provider="Sunspikes\ClamavValidator\ClamavValidatorServiceProvider" --tag=lang
+
+This will copy the language files to `resources/lang/vendor/clamav-validator` for Laravel >= 5.1
 
 <a name="usage"></a>
 ## Usage
@@ -77,7 +96,7 @@ $rules = array(
 
 By default the package will try to connect the clamav daemon via the default socket file (/var/run/clamav/clamd.ctl) and if it fails it will try the tcp port (127.0.0.1:3310)
 
-But you can set the `CLAMAV_UNIX_SOCKET` (socket file path) or `CLAMAV_LOCAL_TCP_SOCKET` (host:port) environment variables to override this.
+But you can set the `CLAMAV_UNIX_SOCKET` (socket file path) or `CLAMAV_TCP_SOCKET` (host:port) environment variables to override this.
 
 <a name="author"></a>
 ## Author

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": ">=5.4.0",
         "xenolope/quahog": "2.*",
-        "illuminate/support": ">=4.2",
-        "illuminate/validation": ">=4.1.21"
+        "illuminate/support": "^5.0",
+        "illuminate/validation": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/config/clamav.php
+++ b/config/clamav.php
@@ -1,0 +1,39 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Preferred socket
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the socket which is used, which is unix_socket or tcp_socket.
+    |
+    | Please note if the unix_socket is used and the socket-file is not found the tcp socket will be
+    | used as fallback.
+    */
+    'preferred_socket' => env('CLAMAV_PREFERRED_SOCKET', 'unix_socket'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Unix Socket
+    |--------------------------------------------------------------------------
+    | This option defines the location to the unix socket-file. For example
+    | /var/run/clamav/clamd.ctl
+    */
+    'unix_socket' => env('CLAMAV_UNIX_SOCKET', '/var/run/clamav/clamd.ctl'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | TCP Socket
+    |--------------------------------------------------------------------------
+    | This option defines the TCP socket to the ClamAV instance.
+    */
+    'tcp_socket' => env('CLAMAV_TCP_SOCKET', 'tcp://127.0.0.1:3310'),
+    /*
+    |--------------------------------------------------------------------------
+    | Socket read timeout
+    |--------------------------------------------------------------------------
+    | This option defines the maximum time to wait in seconds for a read.
+    */
+    'socket_read_timeout' => env('CLAMAV_SOCKET_READ_TIMEOUT', 30)
+];

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -1,6 +1,7 @@
 <?php namespace Sunspikes\ClamavValidator;
 
 use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Validation\Validator;
 use Xenolope\Quahog\Client;
 use Socket\Raw\Factory;
@@ -17,21 +18,6 @@ class ClamavValidator extends Validator
      * @const string CLAMAV_STATUS_ERROR
      */
     const CLAMAV_STATUS_ERROR = 'ERROR';
-
-    /**
-     * @const string CLAMAV_UNIX_SOCKET
-     */
-    const CLAMAV_UNIX_SOCKET = '/var/run/clamav/clamd.ctl';
-
-    /**
-     * @const string CLAMAV_LOCAL_TCP_SOCKET
-     */
-    const CLAMAV_LOCAL_TCP_SOCKET = 'tcp://127.0.0.1:3310';
-
-    /**
-     * @const string CLAMAV_SOCKET_READ_TIMEOUT
-     */
-    const CLAMAV_SOCKET_READ_TIMEOUT = 30;
 
     /**
      * Creates a new instance of ClamavValidator]
@@ -72,7 +58,7 @@ class ClamavValidator extends Validator
         $socket = (new Factory())->createClient($clamavSocket);
 
         // Create a new instance of the Client
-        $quahog = new Client($socket, self::CLAMAV_SOCKET_READ_TIMEOUT, PHP_NORMAL_READ);
+        $quahog = new Client($socket, Config::get('clamav.socket_read_timeout'), PHP_NORMAL_READ);
 
         // Check if the file is readable
         if (! is_readable($file)) {
@@ -97,11 +83,16 @@ class ClamavValidator extends Validator
      */
     protected function getClamavSocket()
     {
-        if (file_exists(env('CLAMAV_UNIX_SOCKET', self::CLAMAV_UNIX_SOCKET))) {
-            return 'unix://' . env('CLAMAV_UNIX_SOCKET', self::CLAMAV_UNIX_SOCKET);
-        }
+        $preferredSocket = Config::get('clamav.preferred_socket');
 
-        return env('CLAMAV_TCP_SOCKET', self::CLAMAV_LOCAL_TCP_SOCKET);
+        if ($preferredSocket === 'unix_socket') {
+            $unixSocket = Config::get('clamav.unix_socket');
+            if (file_exists($unixSocket)) {
+                return 'unix://' . $unixSocket;
+            }
+        }
+        // We use the tcp_socket as fallback as well
+        return Config::get('clamav.tcp_socket');
     }
 
     /**

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -30,24 +30,26 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'clamav-validator');
 
-        $this->publishes([
-            __DIR__ . '/../../config/clamav.php' => config_path('clamav.php'),
-        ], 'config');
-        $this->publishes([
-        __DIR__.'/../lang' => resource_path('lang/vendor/clamav-validator'),
-        ], 'lang');
-        $this->app['validator']
-            ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
-                return new ClamavValidator(
-                    $translator,
-                    $data,
-                    $rules,
-                    $messages,
-                    $customAttributes
-                );
-            });
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../../config/clamav.php' => config_path('clamav.php'),
+            ], 'config');
+            $this->publishes([
+            __DIR__.'/../lang' => resource_path('lang/vendor/clamav-validator'),
+            ], 'lang');
+            $this->app['validator']
+                ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
+                    return new ClamavValidator(
+                        $translator,
+                        $data,
+                        $rules,
+                        $messages,
+                        $customAttributes
+                    );
+                });
 
-        $this->addNewRules();
+            $this->addNewRules();
+        }
     }
 
     /**

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -15,7 +15,7 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     /**
      * The list of validator rules.
      *
-     * @var bool
+     * @var array
      */
     protected $rules = [
         'clamav',
@@ -30,6 +30,12 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(__DIR__ . '/../lang', 'clamav-validator');
 
+        $this->publishes([
+            __DIR__ . '/../../config/clamav.php' => config_path('clamav.php'),
+        ], 'config');
+        $this->publishes([
+        __DIR__.'/../lang' => resource_path('lang/vendor/clamav-validator'),
+        ], 'lang');
         $this->app['validator']
             ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
                 return new ClamavValidator(
@@ -76,8 +82,11 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     {
         $method = studly_case($rule);
         $translation = $this->app['translator']->get('clamav-validator::validation');
-        $this->app['validator']->extend($rule, ClamavValidator::class .'@validate' . $method,
-            isset($translation[$rule]) ? $translation[$rule] : []);
+        $this->app['validator']->extend(
+            $rule,
+            ClamavValidator::class .'@validate' . $method,
+            isset($translation[$rule]) ? $translation[$rule] : []
+        );
     }
 
 
@@ -88,6 +97,7 @@ class ClamavValidatorServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../../config/clamav.php', 'clamav');
     }
 
 


### PR DESCRIPTION
According to the Laravel documentation (https://laravel.com/docs/5.6/configuration#configuration-caching) you should not use the env function outside configuration files:

`If you execute the config:cache command during your deployment process, you should be sure that you are only calling the env function from within your configuration files. Once the configuration has been cached, the .env file will not be loaded and all calls to the env function will return null.`

The current code does use the  `env` function
https://github.com/sunspikes/clamav-validator/blob/19f690f97afadd5d3bdfb930b33fb2f36e7f68f1/src/ClamavValidator/ClamavValidator.php#L100-L104

This pull request introduces a configuration file to be able to use config:cache as recommended by Laravel.

The config file allows to define:
- preferred socket (unix_socket or tcp_socket)
- unix_socket
- tcp_socket
- socket_read_timeout

The preferred socket can be used to use the tcp socket directly instead of the unix socket.
This pull request also introduce the possibility to customize the translation.