### PR TITLE
Update tcp socket variable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $rules = array(
 
 By default the package will try to connect the clamav daemon via the default socket file (/var/run/clamav/clamd.ctl) and if it fails it will try the tcp port (127.0.0.1:3310)
 
-But you can set the `CLAMAV_UNIX_SOCKET` (socket file path) or `CLAMAV_LOCAL_TCP_SOCKET` (host:port) environment variables to override this.
+But you can set the `CLAMAV_UNIX_SOCKET` (socket file path) or `CLAMAV_TCP_SOCKET` (host:port) environment variables to override this.
 
 <a name="author"></a>
 ## Author


### PR DESCRIPTION
CLAMAV_LOCAL_TCP_SOCKET is not the used variable, CLAMAV_TCP_SOCKET is used in the code (ClamavValidator.php:104)