### PR TITLE
Simplify validator comparison statement

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -87,7 +87,7 @@ class ClamavValidator extends Validator
         }
 
         // Check if scan result is not clean
-        return !(self::CLAMAV_STATUS_OK !== $result['status']);
+        return self::CLAMAV_STATUS_OK === $result['status'];
     }
 
     /**

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -9,16 +9,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class ClamavValidator extends Validator
 {
     /**
-     * @const string CLAMAV_STATUS_OK
-     */
-    const CLAMAV_STATUS_OK = 'OK';
-
-    /**
-     * @const string CLAMAV_STATUS_ERROR
-     */
-    const CLAMAV_STATUS_ERROR = 'ERROR';
-
-    /**
      * @const string CLAMAV_UNIX_SOCKET
      */
     const CLAMAV_UNIX_SOCKET = '/var/run/clamav/clamd.ctl';
@@ -82,12 +72,12 @@ class ClamavValidator extends Validator
         // Scan the file
         $result = $quahog->scanResourceStream(fopen($file, 'rb'));
 
-        if (self::CLAMAV_STATUS_ERROR === $result['status']) {
+        if (Client::RESULT_ERROR === $result['status']) {
             throw new ClamavValidatorException($result['reason']);
         }
 
         // Check if scan result is not clean
-        return self::CLAMAV_STATUS_OK === $result['status'];
+        return Client::RESULT_OK === $result['status'];
     }
 
     /**


### PR DESCRIPTION
1. Simplify Boolean condition on the validation result
2. Use Xenolope\Quahog\Client class constants to validate the result to avoid duplicate constants.