### PR TITLE
Ability to validate multiple files in one request

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ $rules = [
 ];
 ```
 
+`ClamavValidator` will automatically run multiple files one-by-one through ClamAV in case `file` represent multiple uploaded files.
+
 <a name="author"></a>
 ## Author
 

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -49,15 +49,15 @@ class ClamavValidator extends Validator
         }
 
         if(is_array($value)) {
-        	$result = TRUE;    /* Assume all will be well */
+        	$result = true;
         	foreach($value as $file) {
         		$result &= $this->validateFileWithClamAv($file);
 			}
 
         	return $result;
-		} else {
-        	return $this->validateFileWithClamAv($value);
 		}
+
+		return $this->validateFileWithClamAv($value);
 	}
 
 	/**

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -48,6 +48,28 @@ class ClamavValidator extends Validator
             return true;
         }
 
+        if(is_array($value)) {
+        	$result = TRUE;    /* Assume all will be well */
+        	foreach($value as $file) {
+        		$result &= $this->validateFileWithClamAv($file);
+			}
+
+        	return $result;
+		} else {
+        	return $this->validateFileWithClamAv($value);
+		}
+	}
+
+	/**
+	 * Validate the single uploaded file for virus/malware with ClamAV.
+	 *
+	 * @param $value mixed
+	 *
+	 * @return bool
+	 * @throws ClamavValidatorException
+	 */
+	protected function validateFileWithClamAv($value)
+	{
         $file = $this->getFilePath($value);
         if (! is_readable($file)) {
             throw ClamavValidatorException::forNonReadableFile($file);

--- a/tests/ClamavValidatorTest.php
+++ b/tests/ClamavValidatorTest.php
@@ -18,6 +18,8 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
     protected $error_data;
     protected $rules;
     protected $messages;
+    protected $multiple_files_all_clean;
+    protected $multiple_files_some_with_virus;
 
     public function setUp()
     {
@@ -35,6 +37,19 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
         $this->error_data = [
             'file' => $this->getTempPath(__DIR__ . '/files/test3.txt')
         ];
+        $this->multiple_files_all_clean = [
+        	'files' => [
+				$this->getTempPath(__DIR__ . '/files/test1.txt'),
+				$this->getTempPath(__DIR__ . '/files/test4.txt'),
+			]
+		];
+        $this->multiple_files_some_with_virus = [
+			'files' => [
+				$this->getTempPath(__DIR__ . '/files/test1.txt'),
+				$this->getTempPath(__DIR__ . '/files/test2.txt'),
+				$this->getTempPath(__DIR__ . '/files/test4.txt'),
+			]
+		];
         $this->messages = [];
 
         $config = new Config();
@@ -66,6 +81,18 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($validator->passes());
     }
 
+	public function testValidatesCleanMultiFile()
+	{
+		$validator = new ClamavValidator(
+			$this->translator,
+			$this->multiple_files_all_clean,
+			['files' => 'clamav'],
+			$this->messages
+		);
+
+		$this->assertTrue($validator->passes());
+	}
+
     public function testValidatesVirus()
     {
         $validator = new ClamavValidator(
@@ -77,6 +104,18 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($validator->passes());
     }
+
+	public function testValidatesVirusMultiFile()
+	{
+		$validator = new ClamavValidator(
+			$this->translator,
+			$this->multiple_files_some_with_virus,
+			['files' => 'clamav'],
+			$this->messages
+		);
+
+		$this->assertFalse($validator->passes());
+	}
 
     public function testValidatesError()
     {

--- a/tests/files/test4.txt
+++ b/tests/files/test4.txt
@@ -1,0 +1,5 @@
+dfdsfdsfdsf
+ds
+fds
+fdsfds
+fdsfdsfds


### PR DESCRIPTION
For a project I'm working on, we need to have the ability to run multiple files through ClamAV in one request. This PR provides this functionality and leaves the ability to scan single files intact.

Multiple files in one request are marked with naming the parameter with array syntax, e.g. `files[]` instead of just `file` for one file. Thus, it can be determined whether the validator is about to validate one file or multiple files by checking `is_array($value)`. If so, pass each array element through ClamAV and return a combined response. If not (`$value` does not represent an array), just pass that one file through ClamAV and return the result.

I've also extended the testsuite to cover 2 extra MultiFile test cases.
