### PR TITLE
Validator Resolver is overriding custom Validator

### DIFF
--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -4,7 +4,6 @@ namespace Sunspikes\ClamavValidator;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
-use Illuminate\Validation\Validator;
 
 class ClamavValidatorServiceProvider extends ServiceProvider
 {
@@ -40,6 +39,16 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         $this->publishes([
         __DIR__.'/../lang' => $this->app->resourcePath('lang/vendor/clamav-validator'),
         ], 'lang');
+        $this->app['validator']
+            ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
+                return new ClamavValidator(
+                    $translator,
+                    $data,
+                    $rules,
+                    $messages,
+                    $customAttributes
+                );
+            });
 
         $this->addNewRules();
     }
@@ -91,20 +100,6 @@ class ClamavValidatorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->extend('validator', function($service) {
-            $service->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
-                return new ClamavValidator(
-                    $translator,
-                    $data,
-                    $rules,
-                    $messages,
-                    $customAttributes
-                );
-            });
-
-            return $service;
-        });
-
         $this->mergeConfigFrom(__DIR__ . '/../../config/clamav.php', 'clamav');
     }
 

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -4,6 +4,7 @@ namespace Sunspikes\ClamavValidator;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
 
 class ClamavValidatorServiceProvider extends ServiceProvider
 {
@@ -39,16 +40,6 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         $this->publishes([
         __DIR__.'/../lang' => $this->app->resourcePath('lang/vendor/clamav-validator'),
         ], 'lang');
-        $this->app['validator']
-            ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
-                return new ClamavValidator(
-                    $translator,
-                    $data,
-                    $rules,
-                    $messages,
-                    $customAttributes
-                );
-            });
 
         $this->addNewRules();
     }
@@ -100,6 +91,20 @@ class ClamavValidatorServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->extend('validator', function($service) {
+            $service->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
+                return new ClamavValidator(
+                    $translator,
+                    $data,
+                    $rules,
+                    $messages,
+                    $customAttributes
+                );
+            });
+
+            return $service;
+        });
+
         $this->mergeConfigFrom(__DIR__ . '/../../config/clamav.php', 'clamav');
     }
 

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -39,16 +39,6 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         $this->publishes([
         __DIR__.'/../lang' => $this->app->resourcePath('lang/vendor/clamav-validator'),
         ], 'lang');
-        $this->app['validator']
-            ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
-                return new ClamavValidator(
-                    $translator,
-                    $data,
-                    $rules,
-                    $messages,
-                    $customAttributes
-                );
-            });
 
         $this->addNewRules();
     }


### PR DESCRIPTION
We have another validation package, this resolver is overriding the other validation. So we cannot use resolver, but use validator extend instead.

This is to solve the issue for:
https://github.com/sunspikes/clamav-validator/issues/40

source:
https://laracasts.com/discuss/channels/general-discussion/resolving-multiple-custom-validators