### PR TITLE
LivewireUploadedFile fix

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -121,7 +121,7 @@ class ClamavValidator extends Validator
     {
         // if were passed an instance of UploadedFile, return the path
         if ($file instanceof UploadedFile) {
-            return $file->getPathname();
+            return $file->getRealPath();
         }
 
         // if we're passed a PHP file upload array, return the "tmp_name"


### PR DESCRIPTION
The validator currently doesn't work with ```LivewireUploadedFile``` file uploads, it fails at the ```is_readable``` check. Something to do with the temporary uploaded file location.

This fix solves the problem without changing functionality for a standard Laravel ```UploadedFile```