### PR TITLE
Add a config setting for client exceptions

### DIFF
--- a/config/clamav.php
+++ b/config/clamav.php
@@ -40,6 +40,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Throw exceptions instead of returning failures when scan fails.
+    |--------------------------------------------------------------------------
+    | This makes it easier for a developer to find the source of a clamav
+    | failure, but an end user may only see a 500 error for the user
+    | if exceptions are not displayed.
+    */
+    'client_exceptions' => env('CLAMAV_CLIENT_EXCEPTIONS', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Skip validation
     |--------------------------------------------------------------------------
     | This skips the virus validation for current environment.

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -80,11 +80,17 @@ class ClamavValidator extends Validator
             $scanner = $this->createQuahogScannerClient($socket);
             $result  = $scanner->scanResourceStream(fopen($file, 'rb'));
         } catch (\Exception $exception) {
-            throw ClamavValidatorException::forClientException($exception);
+            if (Config::get('clamav.client_exceptions')) {
+                throw ClamavValidatorException::forClientException($exception);
+            }
+            return false;
         }
 
         if (QuahogClient::RESULT_ERROR === $result['status']) {
-            throw ClamavValidatorException::forScanResult($result);
+            if (Config::get('clamav.client_exceptions')) {
+                throw ClamavValidatorException::forScanResult($result);
+            }
+            return false;
         }
 
         // Check if scan result is clean


### PR DESCRIPTION
Exceptions are good for a developer, but can hide errors for end users.

Example, user uploads a file that is too large for clamav (> 25Mb). ClamAV will close the
stream once it hits it's own configured limit. Throwing an exception in this case will show
the user a 500 internal error, instead of showing a useful message (the file size
validation error).

Resolves sunspikes/clamav-validator#50