### PR TITLE
Updated for L9 (#54)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 composer.phar
 composer.lock
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo freshclam
 sudo systemctl enable --now clamav-daemon clamav-freshclam
 ```
 
-This package is not tested on windows, but if you have ClamAV running (usually on port 3310) it should work.
+This package is not tested on Windows, but if you have ClamAV running (usually on port 3310) it should work.
 You will also need to have `sockets` extension installed and enabled (all executions without this module will fail with this error - `"Use of undefined constant 'AF_INET'"`).
 
 <a name="installation"></a>
@@ -59,7 +59,7 @@ If you are using Laravel < 5.5, you need to add `Sunspikes\ClamavValidator\Clama
 	Sunspikes\ClamavValidator\ClamavValidatorServiceProvider::class,
 ],
 ```
-#### 3. Publish assets from the the vendor package
+#### 3. Publish assets from the vendor package
 
 ##### Config file
 
@@ -72,7 +72,7 @@ Once the command is finished you should have a `config/clamav.php` file that wil
 
 ##### Language files
 
-If you want to customize the translation or add your own language you can run the the following command to
+If you want to customize the translation or add your own language you can run the following command to
 publish the language files to a folder you maintain:
 
     php artisan vendor:publish --provider="Sunspikes\ClamavValidator\ClamavValidatorServiceProvider" --tag=lang

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,16 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
-        "xenolope/quahog": "2.*",
-        "illuminate/support": "~5.0 || ^6.0 || ^7.0 || ^8.0",
-        "illuminate/validation": "~5.0 || ^6.0 || ^7.0 || ^8.0"
+        "php": "^7.3|^8.0",
+        "ext-sockets": "*",
+        "xenolope/quahog": "^3.0",
+        "illuminate/support": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "illuminate/validation": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "phpunit/phpunit": "4.*",
-        "mockery/mockery": "1.2.*",
+        "phpunit/phpunit": "^9.5.10",
+        "mockery/mockery": "^1.5.0",
         "scrutinizer/ocular": "dev-master"
     },
     "autoload": {
@@ -41,7 +42,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Sunspikes\\Tests\\ClamavValidator\\": "src/"
+            "Sunspikes\\Tests\\ClamavValidator\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,8 +8,12 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="ClamAV Validator Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/ClamavValidator/ClamavValidatorException.php
+++ b/src/ClamavValidator/ClamavValidatorException.php
@@ -3,13 +3,15 @@
 namespace Sunspikes\ClamavValidator;
 
 use Exception;
+use Xenolope\Quahog\Result;
 
 class ClamavValidatorException extends Exception
 {
     /**
      * @param string $file
+     * @return ClamavValidatorException
      */
-    public static function forNonReadableFile($file)
+    public static function forNonReadableFile(string $file): ClamavValidatorException
     {
         return new self(
             sprintf('The file "%s" is not readable', $file)
@@ -17,24 +19,25 @@ class ClamavValidatorException extends Exception
     }
 
     /**
-     * @param array $result
+     * @param Result $result
+     * @return ClamavValidatorException
      */
-    public static function forScanResult($result)
+    public static function forScanResult(Result $result): ClamavValidatorException
     {
         return new self(
             sprintf(
-                'ClamAV scanner failed to scan file "%s" with error "%s" (%s)',
-                $result['filename'],
-                $result['reason'],
-                $result['status']
+                'ClamAV scanner failed to scan file "%s" with error "%s"',
+                $result->getFilename(),
+                $result->getReason()
             )
         );
     }
 
     /**
-     * @param \Exception $exception
+     * @param Exception $exception
+     * @return ClamavValidatorException
      */
-    public static function forClientException($exception)
+    public static function forClientException(Exception $exception): ClamavValidatorException
     {
         return new self(
             sprintf('ClamAV scanner client failed with error "%s"', $exception->getMessage()),

--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -7,14 +7,6 @@ use Illuminate\Support\Str;
 
 class ClamavValidatorServiceProvider extends ServiceProvider
 {
-
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
     /**
      * The list of validator rules.
      *
@@ -37,7 +29,9 @@ class ClamavValidatorServiceProvider extends ServiceProvider
             __DIR__ . '/../../config/clamav.php' => $this->app->configPath('clamav.php'),
         ], 'config');
         $this->publishes([
-        __DIR__.'/../lang' => $this->app->resourcePath('lang/vendor/clamav-validator'),
+            __DIR__ . '/../lang' => method_exists($this->app, 'langPath') ?
+                $this->app->langPath('vendor/clamav-validator')
+                : $this->app->resourcePath('lang/vendor/clamav-validator'),
         ], 'lang');
         $this->app['validator']
             ->resolver(function ($translator, $data, $rules, $messages, $customAttributes = []) {
@@ -58,7 +52,7 @@ class ClamavValidatorServiceProvider extends ServiceProvider
      *
      * @return array
      */
-    public function getRules()
+    public function getRules(): array
     {
         return $this->rules;
     }
@@ -78,17 +72,17 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     /**
      * Extend the validator with new rules.
      *
-     * @param  string $rule
+     * @param string $rule
      * @return void
      */
-    protected function extendValidator($rule)
+    protected function extendValidator(string $rule)
     {
         $method = Str::studly($rule);
         $translation = $this->app['translator']->get('clamav-validator::validation');
         $this->app['validator']->extend(
             $rule,
-            ClamavValidator::class .'@validate' . $method,
-            isset($translation[$rule]) ? $translation[$rule] : []
+            ClamavValidator::class . '@validate' . $method,
+            $translation[$rule] ?? []
         );
     }
 
@@ -101,16 +95,5 @@ class ClamavValidatorServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/../../config/clamav.php', 'clamav');
-    }
-
-
-    /**
-     * Get the services provided by the provider.
-     *
-     * @return array
-     */
-    public function provides()
-    {
-        return [];
     }
 }

--- a/tests/ClamavValidatorServiceProviderTest.php
+++ b/tests/ClamavValidatorServiceProviderTest.php
@@ -3,8 +3,8 @@
 namespace Sunspikes\Tests\ClamavValidator;
 
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Translation\Translator;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Validation\PresenceVerifierInterface;
 use Mockery;
@@ -27,12 +27,10 @@ class ClamavValidatorServiceProviderTest extends TestCase
         $factory = new Factory($translator);
         $factory->setPresenceVerifier($presence);
 
-        $config = Config::spy();
-
+        /** @var Mockery\Mock|Application $container */
         $container = Mockery::mock(Container::class)->makePartial();
         $container->shouldReceive('offsetGet')->with('translator')->andReturn($translator);
         $container->shouldReceive('offsetGet')->with('validator')->andReturn($factory);
-        $container->shouldReceive('offsetGet')->with('config')->andReturn($config);
         $container->shouldReceive('configPath');
         $container->shouldReceive('resourcePath');
 
@@ -48,13 +46,13 @@ class ClamavValidatorServiceProviderTest extends TestCase
             $this->assertTrue(in_array($rule, $sp->getRules()));
             $this->assertEquals(ClamavValidator::class .'@validate' . Str::studly($rule), $class_and_method);
 
-            list($class, $method) = Str::parseCallback($class_and_method, null);
+            list($class, $method) = Str::parseCallback($class_and_method);
 
             $this->assertTrue(method_exists($class, $method));
         }
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         Mockery::close();
     }

--- a/tests/ClamavValidatorTest.php
+++ b/tests/ClamavValidatorTest.php
@@ -2,15 +2,14 @@
 
 namespace Sunspikes\Tests\ClamavValidator;
 
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Facade;
 use Mockery;
 use Illuminate\Contracts\Translation\Translator;
 use Sunspikes\ClamavValidator\ClamavValidator;
 use Sunspikes\ClamavValidator\ClamavValidatorException;
+use PHPUnit\Framework\TestCase;
 
-class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
+class ClamavValidatorTest extends TestCase
 {
     protected $translator;
     protected $clean_data;
@@ -21,13 +20,12 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
     protected $multiple_files_all_clean;
     protected $multiple_files_some_with_virus;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->translator = Mockery::mock(Translator::class);
         $this->translator->shouldReceive('get')->with('validation.custom.file.clamav')->andReturn('error');
         $this->translator->shouldReceive('get')->withAnyArgs()->andReturn(null);
         $this->translator->shouldReceive('get')->with('validation.attributes')->andReturn([]);
-        $this->translator->shouldReceive('trans');
         $this->clean_data = [
             'file' => $this->getTempPath(__DIR__ . '/files/test1.txt')
         ];
@@ -50,27 +48,48 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
 				$this->getTempPath(__DIR__ . '/files/test4.txt'),
 			]
 		];
-        $this->messages = [];
-
-        $config = new Config();
-        $config->shouldReceive('get')->with('clamav.preferred_socket')->andReturn('unix_socket');
-        $config->shouldReceive('get')->with('clamav.unix_socket')->andReturn('/var/run/clamav/clamd.ctl');
-        $config->shouldReceive('get')->with('clamav.tcp_socket')->andReturn('tcp://127.0.0.1:3310');
-        $config->shouldReceive('get')->with('clamav.socket_read_timeout')->andReturn(30);
-        $config->shouldReceive('get')->with('clamav.skip_validation')->andReturn(false);
-
-        $application = Mockery::mock(Application::class, ['make' => $config]);
-        Facade::setFacadeApplication($application);
+        $this->messages = ['clamav' => ':attribute contains virus.'];
     }
 
-    public function tearDown()
+    private function setConfig(array $opts = []): void
+    {
+        $opts = array_merge(['error' => false, 'skip' => false, 'exception' => false], $opts);
+
+        $config = Mockery::mock();
+        $config->shouldReceive('get')->with('clamav.preferred_socket')->andReturn('unix_socket');
+        $config->shouldReceive('get')->with('clamav.client_exceptions')->andReturn($opts['exception']);
+        $config->shouldReceive('get')->with('clamav.unix_socket')->andReturn(!$opts['error'] ? '/var/run/clamav/clamd.ctl' : '/dev/null');
+        $config->shouldReceive('get')->with('clamav.tcp_socket')->andReturn(!$opts['error'] ? 'tcp://127.0.0.1:3310' : 'tcp://127.0.0.1:0');
+        $config->shouldReceive('get')->with('clamav.socket_read_timeout')->andReturn(30);
+        $config->shouldReceive('get')->with('clamav.skip_validation')->andReturn($opts['skip']);
+
+        Config::swap($config);
+    }
+
+    protected function tearDown(): void
     {
         chmod($this->error_data['file'], 0644);
         Mockery::close();
     }
 
+    public function testValidatesSkipped()
+    {
+        $this->setConfig(['skip' => true]);
+
+        $validator = new ClamavValidator(
+            $this->translator,
+            $this->clean_data,
+            ['file' => 'clamav'],
+            $this->messages
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
     public function testValidatesClean()
     {
+        $this->setConfig();
+
         $validator = new ClamavValidator(
             $this->translator,
             $this->clean_data,
@@ -83,6 +102,8 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
 
 	public function testValidatesCleanMultiFile()
 	{
+        $this->setConfig();
+
 		$validator = new ClamavValidator(
 			$this->translator,
 			$this->multiple_files_all_clean,
@@ -95,6 +116,8 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidatesVirus()
     {
+        $this->setConfig();
+
         $validator = new ClamavValidator(
             $this->translator,
             $this->virus_data,
@@ -102,11 +125,13 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
             $this->messages
         );
 
-        $this->assertFalse($validator->passes());
+        $this->assertTrue($validator->fails());
     }
 
 	public function testValidatesVirusMultiFile()
 	{
+        $this->setConfig();
+
 		$validator = new ClamavValidator(
 			$this->translator,
 			$this->multiple_files_some_with_virus,
@@ -114,12 +139,14 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
 			$this->messages
 		);
 
-		$this->assertFalse($validator->passes());
+		$this->assertTrue($validator->fails());
 	}
 
-    public function testValidatesError()
+    public function testCannotValidateNonReadable()
     {
-        $this->setExpectedException(ClamavValidatorException::class, 'is not readable');
+        $this->setConfig();
+
+        $this->expectException(ClamavValidatorException::class);
 
         $validator = new ClamavValidator(
             $this->translator,
@@ -133,13 +160,43 @@ class ClamavValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->passes();
     }
 
+    public function testFailsValidationOnError()
+    {
+        $this->setConfig(['error' => true]);
+
+        $validator = new ClamavValidator(
+            $this->translator,
+            $this->clean_data,
+            ['file' => 'clamav'],
+            $this->messages
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function testThrowsExceptionOnValidationError()
+    {
+        $this->setConfig(['error' => true, 'exception' => true]);
+
+        $this->expectException(ClamavValidatorException::class);
+
+        $validator = new ClamavValidator(
+            $this->translator,
+            $this->clean_data,
+            ['file' => 'clamav'],
+            $this->messages
+        );
+
+        $this->assertTrue($validator->fails());
+    }
+
     /**
      * Move to temp dir, so that clamav can access the file
      *
      * @param $file
      * @return string
      */
-    private function getTempPath($file)
+    private function getTempPath($file): string
     {
         $tempPath = sys_get_temp_dir() . DIRECTORY_SEPARATOR . basename($file);
         copy($file, $tempPath);


### PR DESCRIPTION
Minimum PHP version required is now 7.3
Updated xenolope/quahog, phpunit/phpunit and mockery/mockery dependency versions
Added sockets extension dependency
Added additional tests for increased code coverage