### PR TITLE
Append vendor path for language file

### DIFF
--- a/src/ClamavValidator/ClamavValidatorServiceProvider.php
+++ b/src/ClamavValidator/ClamavValidatorServiceProvider.php
@@ -30,7 +30,7 @@ class ClamavValidatorServiceProvider extends ServiceProvider
         ], 'config');
         $this->publishes([
             __DIR__ . '/../lang' => method_exists($this->app, 'langPath') ?
-                $this->app->langPath('vendor/clamav-validator')
+                $this->app->langPath().'/vendor/clamav-validator'
                 : $this->app->resourcePath('lang/vendor/clamav-validator'),
         ], 'lang');
         $this->app['validator']


### PR DESCRIPTION
[`langPath()`](https://laravel.com/api/8.x/Illuminate/Foundation/Application.html#method_langPath) does not take an argument like [`resourcePath()`](https://laravel.com/api/8.x/Illuminate/Foundation/Application.html#method_resourcePath), so the sub-path (`vendor/clamav-validator`) should be appended. Fixes #57 