### PR TITLE
use filter_var for skip config

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -45,7 +45,7 @@ class ClamavValidator extends Validator
      */
     public function validateClamav(string $attribute, $value, array $parameters): bool
     {
-        if (true === Config::get('clamav.skip_validation')) {
+        if (filter_var(Config::get('clamav.skip_validation'), FILTER_VALIDATE_BOOLEAN)) { 
             return true;
         }
 

--- a/tests/ClamavValidatorTest.php
+++ b/tests/ClamavValidatorTest.php
@@ -87,6 +87,20 @@ class ClamavValidatorTest extends TestCase
         $this->assertTrue($validator->passes());
     }
 
+    public function testValidatesSkippedForBoolValidatedConfigValues()
+    {
+        $this->setConfig(['skip' => '1']);
+
+        $validator = new ClamavValidator(
+            $this->translator,
+            $this->clean_data,
+            ['file' => 'clamav'],
+            $this->messages
+        );
+
+        $this->assertTrue($validator->passes());
+    }
+
     public function testValidatesClean()
     {
         $this->setConfig();


### PR DESCRIPTION
When reading env vars from, for example, phpunit.xml, Laravel will convert "true" to "1" so this change catches those cases.