### PR TITLE
Added null protection on validation

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -45,7 +45,7 @@ class ClamavValidator extends Validator
      */
     public function validateClamav(string $attribute, $value, array $parameters): bool
     {
-        if (true === Config::get('clamav.skip_validation')) {
+        if (! $value || true === Config::get('clamav.skip_validation')) {
             return true;
         }
 


### PR DESCRIPTION
We use this package in our company and we had a situation when frontend sends a `null` value to the validated field causing an `TypeError` exception to be thrown like so:
```
/.../vendor/sunspikes/clamav-validator/src/ClamavValidator/ClamavValidator.php:140

Sunspikes\ClamavValidator\ClamavValidator::getFilePath(): Return value must be of type string, null returned
```
This PR resolves that by skipping a validation if the validated field is `null`.