### PR TITLE
Support PHP wrappers (e.g. data://)

### DIFF
--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -72,10 +72,11 @@ class ClamavValidator extends Validator
 	protected function validateFileWithClamAv($value): bool
     {
         if (is_resource($value)) {
-            $file = $value;
+            $stream = $value;
         } else {
             $file = $this->getFilePath($value);
-            if (! is_readable($file)) {
+            $stream = fopen($file, 'rb');
+            if ($file === false) {
                 throw ClamavValidatorException::forNonReadableFile($file);
             }
         }
@@ -83,7 +84,6 @@ class ClamavValidator extends Validator
         try {
             $socket = $this->getClamavSocket();
             $scanner = $this->createQuahogScannerClient($socket);
-            $stream = is_resource($file) ? $file : fopen($file, 'rb');
             $result = $scanner->scanResourceStream($stream);
         } catch (Exception $exception) {
             if (Config::get('clamav.client_exceptions')) {

--- a/src/ClamavValidator/ClamavValidator.php
+++ b/src/ClamavValidator/ClamavValidator.php
@@ -76,7 +76,7 @@ class ClamavValidator extends Validator
         } else {
             $file = $this->getFilePath($value);
             $stream = fopen($file, 'rb');
-            if ($file === false) {
+            if ($stream === false) {
                 throw ClamavValidatorException::forNonReadableFile($file);
             }
         }


### PR DESCRIPTION
This PR makes a rather simple change which drops use of the is_readable() method and instead relies directly on fopen. Given that fopen will return false if the file isn't readable, the use of is_readable() here is redundant. More importantly this allows support for wrappers (https://www.php.net/manual/en/wrappers.php) to be scanned for viruses.

For my particular use case this involved use of the data:// wrapper (https://www.php.net/manual/en/wrappers.data.php) to scan files encoded in base64 for viruses. Since the data wrapper is a string it would fail both the is_resource and is_readable check even though fopen has no issue reading a data wrapper string.