### PR TITLE
Laravel 12 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "php": "^7.3|^8.0",
         "ext-sockets": "*",
         "xenolope/quahog": "^3.0",
-        "illuminate/support": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "illuminate/validation": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
+        "illuminate/support": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/validation": "~5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Updated composer.json to support Laravel 12. All tests still pass and it works fine in an example project I have running locally (tested with a couple of the EICAR files). I messed around with bumping the PHPUnit version as well, but it introduced a warning and some deprecations that I don't have time to deal with right now, so I ended up leaving that alone.